### PR TITLE
Refactor: making cli translate easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project uses [LibreTranslate](https://github.com/LibreTranslate/LibreTransl
 > DISCLAIMER! To be 100% legal please use LibreTranslate engine or use the official Bing or Google Translate API.
 
 ```sh
-npx i18n-populator translate "Hello world" "en" "greetings" --engine "bing"
+npx i18n-populator translate --text "Hello world" --from "en" --name "greetings" --engine "bing"
 
 ```
 
@@ -87,14 +87,14 @@ Also you can check an example on [configuration file](./i18n-populator.config.js
 2. In order to translate, you need to run the `translate` command, write the phrase you want to translate and select the source language that it is wrote in, and at the end add a name for your new translation, this will be used on your json files as property name.
 
 ```sh
-npx i18n-populator translate "Hello world" "en" "greetings"
+npx i18n-populator translate --text "Hello world" --from "en" --name "greetings"
 
 ```
 
 Another example in spanish
 
 ```sh
-npx i18n-populator translate "Hola mundo" "es" "greetings"
+npx i18n-populator translate --text "Hola mundo" --from "es" --name "greetings"
 
 ```
 
@@ -105,13 +105,13 @@ Also, additionally you can specify the path of the configuration file, by defaul
 For example
 
 ```sh
-npx i18n-populator translate "Hello world" "en" "greetings" -s "example/custom-setting.config.json"
+npx i18n-populator translate --text "Hello world" --from "en" --name "greetings" --settings-file "example/custom-setting.config.json"
 
 ```
 
 ### Choosing translation engine
 
-Currently there are two translation engines available, Google Translate and Bing Translate. There are two ways to configure the engine(s) that you want to use. The first one is specifying the engines on the configuration file, and the second one is specifying the engine that you want to use on the command.
+Currently there are three translation engines available, Google Translate, Bing Translate and LibreTranslate. There are two ways to configure the engine(s) that you want to use. The first one is specifying the engines on the configuration file, and the second one is specifying the engine that you want to use on the command.
 
 #### How it works
 
@@ -157,7 +157,7 @@ If you don't specify any engine, the program will try to get your preferences fr
 For example:
 
 ```sh
-npx i18n-populator translate "Welcome to the jungle" "en" "welcomeMessage" -e "bing"
+npx i18n-populator translate --text "Welcome to the jungle" --from "en" --name "welcomeMessage" --engine "bing"
 
 ```
 
@@ -166,7 +166,7 @@ npx i18n-populator translate "Welcome to the jungle" "en" "welcomeMessage" -e "b
 You can nest translations by using the `.` character on the property name parameter, for example:
 
 ```sh
-npx i18n-populator translate "Account settings" "en" "accountSettings.title"
+npx i18n-populator translate --text "Account settings" --from "en" --name "accountSettings.title"
 
 ```
 
@@ -181,7 +181,7 @@ npx i18n-populator translate "Account settings" "en" "accountSettings.title"
 You can continue nesting translations as much as you want.
 
 ```sh
-npx i18n-populator translate "Email" "en" "accountSettings.email"
+npx i18n-populator translate --text "Email" --from "en" --name "accountSettings.email"
 
 ```
 
@@ -195,7 +195,7 @@ npx i18n-populator translate "Email" "en" "accountSettings.email"
 ```
 
 ```sh
-npx i18n-populator translate "Are you sure you want to change your email?" "en" "accountSettings.modal.edit.title"
+npx i18n-populator translate --text "Are you sure you want to change your email?" --from "en" --name "accountSettings.modal.edit.title"
 
 ```
 
@@ -213,7 +213,7 @@ npx i18n-populator translate "Are you sure you want to change your email?" "en" 
 }
 ```
 
-## Configuration file
+## Parts of configuration file
 
 The configuration file is an json file which allow you to modify certain aspects of the project, like the languages that you want to translate, the path of the translations files, etc. Here is a list of the properties that you can modify on the configuration file.
 
@@ -225,9 +225,9 @@ The configuration file is an json file which allow you to modify certain aspects
 
 ## Commands
 
-| Command     | Description                                                                 | Arguments                                                                                                                                                                                                                               | Options                                                                                                                                                        | Example                                                |
-| ----------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `translate` | Translate a text to all the languages that you're handling on your project. | `text`: The word or sentence that you want to translate. `sourceLanguage`: The language of the text that you wrote on `text`.`propertyName`: The property name that you want to be used to include your new translation on your project | `--engine, -e`: The translation engine that you want to use. `--settings-file, -s`: Custom path for the settings file. Default is "i18n-populator.config.json" | `npx i18n-populator translate "my text" "en" "myText"` |
-| `help`      | Show the help menu with all the available commands.                         |                                                                                                                                                                                                                                         |                                                                                                                                                                | `npx i18n-populator help`                              |
-| `languages` | Show the supported languages of all the engines or filter it by engines.    |                                                                                                                                                                                                                                         | `--by-engine, -be`: Filter the supported languages by engine.                                                                                                  | `npx i18n-populator languages`                         |
-| `init`      | Start the configuration wizard to create the settings file                  |                                                                                                                                                                                                                                         |                                                                                                                                                                | `npx i18n-populator init`                              |
+| Command     | Description                                                                 | Arguments                                                                                                                                                                                                                               | Options                                                                                                                                                        | Example                                                                             |
+| ----------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `translate` | Translate a text to all the languages that you're handling on your project. | `--text, -t`: The word or sentence that you want to translate. `--from, -f`: The language of the text that you wrote on `text`.`--name, -n`: The property name that you want to be used to include your new translation on your project | `--engine, -e`: The translation engine that you want to use. `--settings-file, -s`: Custom path for the settings file. Default is "i18n-populator.config.json" | `npx i18n-populator translate --text "Hello world!" --from "en" --name "greetings"` |
+| `help`      | Show the help menu with all the available commands.                         |                                                                                                                                                                                                                                         |                                                                                                                                                                | `npx i18n-populator help`                                                           |
+| `languages` | Show the supported languages of all the engines or filter it by engines.    |                                                                                                                                                                                                                                         | `--by-engine, -be`: Filter the supported languages by engine.                                                                                                  | `npx i18n-populator languages`                                                      |
+| `init`      | Start the configuration wizard to create the settings file                  |                                                                                                                                                                                                                                         |                                                                                                                                                                | `npx i18n-populator init`                                                           |

--- a/cli.js
+++ b/cli.js
@@ -24,11 +24,11 @@ program
   .option("-n, --name <string>", "Name of the translation")
   .option(
     "-e, --engine <string>",
-    "Engine to use for the translation. In case you don't define it will be use by default all the translation engines that are free and doesn't requires API Key.",
+    "[OPTIONAL]. Engine to use for the translation. In case you don't define it will be use by default all the translation engines that are free and doesn't requires API Key.",
   )
   .option(
     "-s, --settings-file <string>",
-    "Path to the settings file",
+    "[OPTIONAL]. Path to the settings file. If not provided, it will look on the current directory for a file named i18n-populator.config.json",
     configPath,
   )
   .action(translateController);

--- a/cli.js
+++ b/cli.js
@@ -19,9 +19,9 @@ program
   .description(
     "Translate a text and put the result on the files in the output directory",
   )
-  .argument("<text>", "Text to translate")
-  .argument("<source-language>", "Source language of the string")
-  .argument("<name-of-translation>", "Name of your translation")
+  .option("-t, --text <string>", "Text to translate")
+  .option("-f, --from <string>", "Source language of the string")
+  .option("-n, --name <string>", "Name of the translation")
   .option(
     "-e, --engine <string>",
     "Engine to use for the translation. In case you don't define it will be use by default all the translation engines that are free and doesn't requires API Key.",

--- a/controllers/translateController.js
+++ b/controllers/translateController.js
@@ -11,6 +11,18 @@ import { validateLanguageRequested } from "../utils/supportedLanguagesUtils.js";
 import { validEngines } from "../utils/translationEnginesUtils.js";
 import { importJSONFile } from "../utils/importJSONFile.js";
 
+/**
+ * Translates a text to multiple languages and saves the translations in the JSON files
+ *
+ * @param {Object} options
+ * @param {string} options.text
+ * @param {string} options.from
+ * @param {string} options.name
+ * @param {string} [options.settingsFile]
+ * @param {string} [options.engine]
+ * @returns {Promise<void>}
+ * @throws {Error}
+ */
 const translateController = async ({
   text,
   from: sourceLanguage,

--- a/controllers/translateController.js
+++ b/controllers/translateController.js
@@ -11,12 +11,12 @@ import { validateLanguageRequested } from "../utils/supportedLanguagesUtils.js";
 import { validEngines } from "../utils/translationEnginesUtils.js";
 import { importJSONFile } from "../utils/importJSONFile.js";
 
-const translateController = async (
+const translateController = async ({
   text,
-  sourceLanguage,
-  nameOfTranslation,
-  options,
-) => {
+  from: sourceLanguage,
+  name: nameOfTranslation,
+  ...options
+}) => {
   const settingsFilePath = parsePath(options.settingsFile);
   await validateSettingsFile(settingsFilePath);
   validateLanguageRequested(sourceLanguage, options.engine);

--- a/controllers/translateController.test.js
+++ b/controllers/translateController.test.js
@@ -49,7 +49,10 @@ describe("TranslateController", () => {
   it("It's calling translate function for each language on config path except for the source language", async () => {
     const { languages } = config;
 
-    await translateController(text, sourceLanguage, nameOfTranslation, {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: nameOfTranslation,
       settingsFile: configPath,
     });
 
@@ -67,7 +70,10 @@ describe("TranslateController", () => {
     fs.existsSync.mockImplementationOnce(() => false);
 
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: "non-existent-file",
       }),
     ).rejects.toThrow("No settings file found");
@@ -76,7 +82,10 @@ describe("TranslateController", () => {
   it("It's calling translate function for each language on config path", async () => {
     const { languages } = config;
 
-    await translateController(text, "fr", nameOfTranslation, {
+    await translateController({
+      text,
+      from: "fr",
+      name: nameOfTranslation,
       settingsFile: configPath,
     });
 
@@ -89,7 +98,10 @@ describe("TranslateController", () => {
     }));
 
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: "test-configs/no-languages.json",
       }),
     ).rejects.toThrow(
@@ -114,7 +126,10 @@ describe("TranslateController", () => {
     );
 
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: "test-configs/invalid-translation-engine.json",
       }),
     ).rejects.toThrow(
@@ -124,7 +139,9 @@ describe("TranslateController", () => {
 
   it("It's throwing an error if text is not provided", async () => {
     await expect(
-      translateController(undefined, sourceLanguage, nameOfTranslation, {
+      translateController({
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: configPath,
       }),
     ).rejects.toThrow("No text to translate provided");
@@ -133,7 +150,9 @@ describe("TranslateController", () => {
   it("It's throwing an error if source language is not provided", async () => {
     const error = new Error("No language provided");
     await expect(
-      translateController(text, undefined, nameOfTranslation, {
+      translateController({
+        text,
+        name: nameOfTranslation,
         settingsFile: configPath,
       }),
     ).rejects.toThrow(
@@ -141,11 +160,14 @@ describe("TranslateController", () => {
     );
   });
 
-  it("It's throwing an error if source language is not supported", async () => {
+  it("It's throwing an error if source language is invalid", async () => {
     const sourceLanguage = "invalid-language";
     const error = new Error(`Language ${sourceLanguage} is not supported`);
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: configPath,
       }),
     ).rejects.toThrow(
@@ -155,7 +177,9 @@ describe("TranslateController", () => {
 
   it("It's throwing an error if name of translation is not provided", async () => {
     await expect(
-      translateController(text, sourceLanguage, undefined, {
+      translateController({
+        text,
+        from: sourceLanguage,
         settingsFile: configPath,
       }),
     ).rejects.toThrow("No name of translation provided");
@@ -179,7 +203,10 @@ describe("TranslateController", () => {
       JSON.stringify(testConfig, null, 2),
     );
 
-    await translateController(text, sourceLanguage, nameOfTranslation, {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: nameOfTranslation,
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -217,7 +244,10 @@ describe("TranslateController", () => {
       JSON.stringify(testConfig, null, 2),
     );
 
-    await translateController(text, sourceLanguage, "nested.helloWorld", {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: "nested.helloWorld",
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -255,12 +285,12 @@ describe("TranslateController", () => {
       JSON.stringify(testConfig, null, 2),
     );
 
-    await translateController(
+    await translateController({
       text,
-      sourceLanguage,
-      "nested.deeply.object.to.test.helloWorld",
-      { settingsFile: "test-configs/test-config.json" },
-    );
+      from: sourceLanguage,
+      name: "nested.deeply.object.to.test.helloWorld",
+      settingsFile: "test-configs/test-config.json",
+    });
 
     expect(
       fs.existsSync(
@@ -296,7 +326,10 @@ describe("TranslateController", () => {
       JSON.stringify(testConfig, null, 2),
     );
 
-    await translateController(text, sourceLanguage, nameOfTranslation, {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: nameOfTranslation,
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -306,7 +339,10 @@ describe("TranslateController", () => {
       ),
     ).toBe(true);
 
-    await translateController(text, sourceLanguage, "helloWorld2", {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: "helloWorld2",
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -341,7 +377,10 @@ describe("TranslateController", () => {
       JSON.stringify(testConfig, null, 2),
     );
 
-    await translateController(text, sourceLanguage, nameOfTranslation, {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: "nested.helloWorld",
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -351,7 +390,10 @@ describe("TranslateController", () => {
       ),
     ).toBe(true);
 
-    await translateController(text, sourceLanguage, "nested.helloWorld", {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: "nested.helloWorld2",
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -381,7 +423,10 @@ describe("TranslateController", () => {
     importJSONFile.mockImplementationOnce(async () => testConfig);
 
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: "test-configs/test-config-without-name.json",
       }),
     ).rejects.toThrow("No name found for language on index 0");
@@ -400,7 +445,10 @@ describe("TranslateController", () => {
     importJSONFile.mockImplementationOnce(async () => testConfig);
 
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: "test-configs/test-config-without-files.json",
       }),
     ).rejects.toThrow(
@@ -422,7 +470,10 @@ describe("TranslateController", () => {
     importJSONFile.mockImplementationOnce(async () => testConfig);
 
     await expect(
-      translateController(text, sourceLanguage, nameOfTranslation, {
+      translateController({
+        text,
+        from: sourceLanguage,
+        name: nameOfTranslation,
         settingsFile: "test-configs/test-config-with-empty-files.json",
       }),
     ).rejects.toThrow(
@@ -451,7 +502,10 @@ describe("TranslateController", () => {
       return file;
     });
 
-    await translateController(text, sourceLanguage, nameOfTranslation, {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: nameOfTranslation,
       settingsFile: "test-configs/test-config.json",
     });
 
@@ -481,7 +535,10 @@ describe("TranslateController", () => {
 
     prompt.mockImplementationOnce(() => "no");
 
-    await translateController(text, sourceLanguage, nameOfTranslation, {
+    await translateController({
+      text,
+      from: sourceLanguage,
+      name: nameOfTranslation,
       settingsFile: "test-configs/test-config.json",
     });
 


### PR DESCRIPTION
When using the CLI tool one problem I faced was remember the order of the parameters. This is why I decide use options instead of arguments for receiving the parameters.

This way, user can define the parameters in the fly while he is thinking. For example, if user thought first on the name of the translation can use it first

```sh
npx i18n-populator translate --name "greetings"
```

then add the text

```sh
npx i18n-populator translate --name "greetings" --text "Hello world!"
```

and at last add the source language

```sh
npx i18n-populator translate --name "greetings" --text "Hello world!" --from "en"
```

This way is easier that checking the doc each time