### PR TITLE
Feat/iss 69/add eof line json file

### DIFF
--- a/controllers/translateController.js
+++ b/controllers/translateController.js
@@ -71,7 +71,7 @@ const translateController = async ({
     filesToEdit.forEach(({ file, parsedPath }) => {
       setDeepValue(file, nameOfTranslation, result);
 
-      fs.writeFileSync(parsedPath, JSON.stringify(file, null, 2));
+      fs.writeFileSync(parsedPath, JSON.stringify(file, null, 2) + "\n");
     });
   }
 };

--- a/controllers/translateController.test.js
+++ b/controllers/translateController.test.js
@@ -557,7 +557,7 @@ describe("TranslateController", () => {
         },
         null,
         2,
-      ),
+      ) + "\n",
     );
 
     expect(fs.writeFileSync).toHaveBeenNthCalledWith(
@@ -569,7 +569,7 @@ describe("TranslateController", () => {
         },
         null,
         2,
-      ),
+      ) + "\n",
     );
 
     expect(fs.writeFileSync).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
# Title
Add newline character to the end of JSON files generated by i18n populator

### Description
This PR addresses an issue where JSON files generated by the i18n populator were missing the trailing newline character (EOF) including a newline character `(\n)` at the end of each JSON file. This ensures consistent file formatting and improves compatibility with various text editors and tools. This often required manual intervention to add the newline, which was inconvenient and error-prone.

### Issue
#69 

### Changes
- Include a newline character `(\n)` at the end of each JSON file

### Checklist:
- [x] Add EOF on JSON file.
